### PR TITLE
Include g elements when converting ids to classes

### DIFF
--- a/tasks/lib/svg/ids-to-classes.js
+++ b/tasks/lib/svg/ids-to-classes.js
@@ -2,7 +2,7 @@
 
 module.exports = function ($, data, done) {
   // Elements on which we want to convert ids to classes...
-  var shapesAndText = 'path,rect,circle,ellipse,line,polyline,polygon,altGlyph,textPath,text,tref,tspan';
+  var shapesAndText = 'g,path,rect,circle,ellipse,line,polyline,polygon,altGlyph,textPath,text,tref,tspan';
 
   // ...but don't touch any in defs/clipPath/masks tags
   var excludeContainers = 'defs,clipPath,mask';


### PR DESCRIPTION
Fixes #3 by adding `g` elements to whitelist.
